### PR TITLE
Always call dotenv.config()

### DIFF
--- a/src/externalLiquidityIncentives.ts
+++ b/src/externalLiquidityIncentives.ts
@@ -33,7 +33,6 @@ import { Ownable__factory } from "@generated/factories/Ownable__factory";
 export const cli = (
   withSignerArgv: <T>(yargs: Argv<T>) => Argv<WithSignerArgs<T>>,
   yargs: Argv,
-  initConfig: () => void,
   getNetwork: <T>(argv: GetNetworkArgv<T>) => { network: string },
   getSigner: <T>(argv: GetSignerArgv<T>) => { network: string; signer: Signer }
 ): Argv => {
@@ -59,8 +58,6 @@ export const cli = (
             require: true,
           }),
       async (argv) => {
-        initConfig();
-
         const { signer } = getSigner(argv);
         const incentives = getExternalLiquidityIncentives(signer, argv);
         const { accountant, permissions: permissionsStr } = argv;
@@ -84,8 +81,6 @@ export const cli = (
           }
         ),
       async (argv) => {
-        initConfig();
-
         const { signer } = getSigner(argv);
         const incentives = getExternalLiquidityIncentives(signer, argv);
         const { accountant } = argv;
@@ -108,8 +103,6 @@ export const cli = (
           )
         ),
       async (argv) => {
-        initConfig();
-
         const { network } = getNetwork(argv);
         const {
           priceStore,
@@ -162,8 +155,6 @@ export const cli = (
             require: true,
           }),
       async (argv) => {
-        initConfig();
-
         const { "liquidity-provider": liquidityProviderAddress, amount } = argv;
         const { signer } = getSigner(argv);
         const rewardsToken = getRewardsToken(signer, argv);
@@ -221,8 +212,6 @@ export const cli = (
             required: true,
           }),
       async (argv) => {
-        initConfig();
-
         const {
           "range-start": rangeStartStr,
           "range-end": rangeEndStr,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ import * as externalLiquidityIncentives from "./externalLiquidityIncentives";
 import * as uniswap from "./uniswap";
 
 const main = async () => {
+  dotenv.config();
+
   await yargs(process.argv.slice(2))
     .command(
       ["changePosition"],
@@ -200,19 +202,13 @@ const main = async () => {
           (yargs) => withSignerArgv(exchangeWithProviderArgv(yargs)),
           yargs
         ),
-      async (argv) =>
-        await liquidationBot.run(
-          () => dotenv.config(),
-          getExchangeWithSigner,
-          argv
-        )
+      async (argv) => await liquidationBot.run(getExchangeWithSigner, argv)
     )
     .command("uniswap", "Interaction with Uniswap", (yargs) =>
       uniswap.cli(
         withNetworkArgv,
         withProviderArgv,
         yargs,
-        () => dotenv.config(),
         getNetwork,
         getProvider
       )
@@ -224,7 +220,6 @@ const main = async () => {
         externalLiquidityIncentives.cli(
           withSignerArgv,
           yargs,
-          () => dotenv.config(),
           getNetwork,
           getSigner
         )

--- a/src/liquidationBot/index.ts
+++ b/src/liquidationBot/index.ts
@@ -103,7 +103,6 @@ export const cli = <Parent>(
 };
 
 export const run = async (
-  initConfig: () => void,
   getExchangeWithSigner: <T>(argv: GetExchangeWithSignerArgv<T>) => {
     network: string;
     signer: Signer;
@@ -113,8 +112,6 @@ export const run = async (
   },
   argv: Arguments<LiquidationBotArgs<{}>>
 ) => {
-  initConfig();
-
   const { network, signer, exchange, exchangeEvents } =
     getExchangeWithSigner(argv);
 

--- a/src/uniswap.ts
+++ b/src/uniswap.ts
@@ -79,7 +79,6 @@ export const cli = (
   withNetworkArgv: <T>(yargs: Argv<T>) => Argv<WithNetworkArgs<T>>,
   withProviderArgv: <T>(yargs: Argv<T>) => Argv<WithProviderArgs<T>>,
   yargs: Argv,
-  initConfig: () => void,
   getNetwork: <T>(argv: GetNetworkArgv<T>) => { network: string },
   getProvider: <T>(argv: GetProviderArgv<T>) => {
     network: string;
@@ -101,7 +100,6 @@ export const cli = (
         const { network } = getNetwork(argv);
         const { priceStore } = argv;
 
-        initConfig();
         const config = configForNetwork(network);
 
         await updateBinancePrices(config, priceStore);
@@ -129,7 +127,6 @@ export const cli = (
       async (argv) => {
         const { fromBlock, toBlock } = argv;
 
-        initConfig();
         const { network, provider } = getProvider(argv);
         const config = configForNetwork(network);
 
@@ -154,7 +151,6 @@ export const cli = (
       async (argv) => {
         const { liquidityBalanceStore } = argv;
 
-        initConfig();
         const { network, provider } = getProvider(argv);
         const config = configForNetwork(network);
 
@@ -167,8 +163,6 @@ export const cli = (
         " and Uniswap liquidity balances.",
       (yargs) => reportCommandOptions(withNetworkArgv(yargs)),
       async (argv) => {
-        initConfig();
-
         const { network } = getNetwork(argv);
         const {
           priceStore,


### PR DESCRIPTION
As we do not need `dotenv` to depend on the command line arguments, for
now, we can just initialize it at the very beginning of `main()` and
remove this dependency from all the individual command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/futureswap/fs-cli-v4/18)
<!-- Reviewable:end -->
