### PR TITLE
LiquidationBotApi: Reduce max traders per check

### DIFF
--- a/src/liquidationBot/cli.ts
+++ b/src/liquidationBot/cli.ts
@@ -79,6 +79,8 @@ const DEFAULT_EXCHANGE_LAUNCH_BLOCK: {
 
 const DEFAULT_MAX_BLOCKS_PER_JSON_RPC_QUERY = 50_000;
 
+const DEFAULT_MAX_TRADERS_PER_LIQUIDATION_CHECK = 300;
+
 const DEFAULT_LIQUIDATION_BOT_API: {
   [network in Network]?: { [version in DeploymentVersion]: string };
 } = {
@@ -194,7 +196,7 @@ export const liquidationBotArgv = <T = {}>(
         describe:
           "Number of addresses to send in a single liquidation request.\n" +
           ".env property: MAX_TRADERS_PER_LIQUIDATION_CHECK\n" +
-          "Default: 1_000",
+          `Default: ${DEFAULT_MAX_TRADERS_PER_LIQUIDATION_CHECK}`,
         type: "number",
       })
       .option("reporting", {
@@ -311,7 +313,11 @@ const getLiquidationBotCommonArgs = <T = {}>(
     "max-traders-per-liquidation-check",
     "MAX_TRADERS_PER_LIQUIDATION_CHECK",
     argv,
-    { isInt: true, isPositive: true, default: 1_000 }
+    {
+      isInt: true,
+      isPositive: true,
+      default: DEFAULT_MAX_TRADERS_PER_LIQUIDATION_CHECK,
+    }
   );
 
   const reporting = getEnumArg(


### PR DESCRIPTION
Running transactions with 1000 addresses fails, with a rather obscure
error message.  Reducing it to 300.  400 was failing with Alchemy.

When the number of open positions exceeds the amount of traders that we
can check per single transaction we effectively issue two (or more)
transactions per liquidation check.  Which may increase the JSON-RPC
provider endpoint load above the free layer limit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/futureswap/fs-cli-v4/34)
<!-- Reviewable:end -->
