### PR TITLE
Reduce maxTradersPerLiquidationCheck to 100

### DIFF
--- a/src/liquidationBot/cli.ts
+++ b/src/liquidationBot/cli.ts
@@ -62,12 +62,12 @@ const DEFAULTS: {
     },
     maxBlocksPerJsonRpcQuery: 50_000,
     historyFetchIntervalSec: 1,
-    maxTradersPerLiquidationCheck: 300,
+    maxTradersPerLiquidationCheck: 100,
   },
   MAINNET_AVALANCHE: {
     maxBlocksPerJsonRpcQuery: 2_000,
     historyFetchIntervalSec: 5,
-    maxTradersPerLiquidationCheck: 300,
+    maxTradersPerLiquidationCheck: 100,
   },
   TESTNET_ARBITRUM: {
     v4: {
@@ -81,7 +81,7 @@ const DEFAULTS: {
     },
     maxBlocksPerJsonRpcQuery: 50_000,
     historyFetchIntervalSec: 1,
-    maxTradersPerLiquidationCheck: 300,
+    maxTradersPerLiquidationCheck: 100,
   },
   TESTNET_AVALANCHE: {
     v4_1: {
@@ -97,7 +97,7 @@ const DEFAULTS: {
     },
     maxBlocksPerJsonRpcQuery: 2_000,
     historyFetchIntervalSec: 5,
-    maxTradersPerLiquidationCheck: 300,
+    maxTradersPerLiquidationCheck: 100,
   },
 };
 


### PR DESCRIPTION
I've seen Alchemy returning timeout errors for 300 traders per check.